### PR TITLE
Account for else clauses in if return simplification

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -663,7 +663,7 @@ func LintSimplerReturn(f *lint.File) {
 
 			// if <id1> != nil
 			ifs, ok := stmt.(*ast.IfStmt)
-			if !ok || len(ifs.Body.List) != 1 {
+			if !ok || len(ifs.Body.List) != 1 || ifs.Else != nil {
 				continue
 			}
 			expr, ok := ifs.Cond.(*ast.BinaryExpr)

--- a/testdata/if-simpler-return.go
+++ b/testdata/if-simpler-return.go
@@ -1,5 +1,7 @@
 package pkg
 
+import "errors"
+
 func fn1() error {
 	var err error
 
@@ -65,6 +67,15 @@ func fn3() error {
 	}
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func fn4(i int, err error) error {
+	if err != nil {
+		return err
+	} else if i == 1 {
+		return errors.New("some non-nil error")
 	}
 	return nil
 }


### PR DESCRIPTION
The example in fn4() was triggering a false positive in some code of mine.
