### PR TITLE
Add directory argument to testutil.TestAll

### DIFF
--- a/lint_test.go
+++ b/lint_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestAll(t *testing.T) {
-	testutil.TestAll(t, Funcs)
+	testutil.TestAll(t, Funcs, "")
 }


### PR DESCRIPTION
dominikh/go-lint@a730e73f0085f274d67b586a1d587fd6e42e6708 introduces a new argument to `testutil.TestAll` to run tests in a `testdata/` subdirectory, this updates go-simple to provide an empty value.

``` bash
root@2c4b1aaccc8a:/go# go get honnef.co/go/simple/cmd/gosimple
root@2c4b1aaccc8a:/go# go test honnef.co/go/simple
# honnef.co/go/simple
src/honnef.co/go/simple/lint_test.go:10: not enough arguments in call to testutil.TestAll
FAIL    honnef.co/go/simple [build failed]
```
