### PR TITLE
Suggest bytes.ContainsAny/ContainsRune instead of IndexAny/IndexRune

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -229,9 +229,6 @@ func LintStringsContains(f *lint.File) {
 		if pkgIdent.Name != "strings" && pkgIdent.Name != "bytes" {
 			return true
 		}
-		if pkgIdent.Name == "bytes" && funIdent.Name != "Index" {
-			return true
-		}
 		newFunc := ""
 		switch funIdent.Name {
 		case "IndexRune":

--- a/testdata/contains.go
+++ b/testdata/contains.go
@@ -33,5 +33,9 @@ func fn() {
 	_ = strings.Index("", "") != 0
 	_ = strings.Index("", "") < 0 // MATCH /!strings.Contains/
 
+	_ = bytes.IndexRune("", 'x') > -1 // MATCH / bytes.ContainsRune/
+
+	_ = bytes.IndexAny("", "") > -1 // MATCH / bytes.ContainsAny/
+
 	_ = bytes.Index(nil, nil) > -1 // MATCH / bytes.Contains/
 }


### PR DESCRIPTION
bytes.ContainsAny and bytes.ContainsRune have been added in Go 1.7.

Fixes #6.
