### PR TITLE
Don't specify default len/cap sizes to make

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ constructs:
 | S1015 | Using `strconv.FormatInt` when `strconv.Atoi` would be more straightforward |                                                                        |
 | S1016 | Converting two struct types by manually copying each field                  | A type conversion: `T(v)`                                              |
 | S1017 | `if strings.HasPrefix` + string slicing                                     | Call `strings.TrimPrefix` unconditionally                              |
+| S1018 | Providing default length or capacity arguments to `make`                    | The length or capacity arguments are redundant                         |
 
 ## gofmt -r
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ constructs:
 | S1015 | Using `strconv.FormatInt` when `strconv.Atoi` would be more straightforward |                                                                        |
 | S1016 | Converting two struct types by manually copying each field                  | A type conversion: `T(v)`                                              |
 | S1017 | `if strings.HasPrefix` + string slicing                                     | Call `strings.TrimPrefix` unconditionally                              |
-| S1018 | Providing default length or capacity arguments to `make`                    | The length or capacity arguments are redundant                         |
+| S1018 | `make(T, 0)` or `make(T, x, x)`                                             | `make(T)` or `make(T, x)`                                              |
 
 ## gofmt -r
 

--- a/lint.go
+++ b/lint.go
@@ -1284,6 +1284,9 @@ func LintMakeLenCap(f *lint.File) {
 		switch len(call.Args) {
 		case 2:
 			// make(T, len)
+			if _, ok := call.Args[0].(*ast.ArrayType); ok {
+				break
+			}
 			if length, ok := call.Args[1].(*ast.BasicLit); ok && length.Value == "0" {
 				f.Errorf(call.Args[1], "when length is zero, length can be omitted")
 			}

--- a/lint.go
+++ b/lint.go
@@ -33,6 +33,7 @@ var Funcs = map[string]lint.Func{
 	"S1015": LintFormatInt,
 	"S1016": LintSimplerStructConversion,
 	"S1017": LintTrim,
+	"S1018": LintMakeLenCap,
 }
 
 type Checker struct{}
@@ -1269,4 +1270,66 @@ func intLit(f *lint.File, expr ast.Expr) (int64, bool) {
 	}
 	val, _ := constant.Int64Val(tv.Value)
 	return val, true
+}
+
+func LintMakeLenCap(f *lint.File) {
+	fn := func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if fn, ok := call.Fun.(*ast.Ident); !ok || fn.Name != "make" {
+			return true
+		}
+		switch len(call.Args) {
+		case 2:
+			// make(T, len)
+			if length, ok := constantInt(f, call.Args[1]); ok && length == 0 {
+				f.Errorf(call.Args[1], "when length is zero, length can be omitted")
+			}
+		case 3:
+			// make(T, len, cap)
+			lenConst, lenOK := constantInt(f, call.Args[1])
+			capConst, capOK := constantInt(f, call.Args[2])
+			if lenOK && capOK && lenConst == capConst {
+				f.Errorf(call.Args[1], "when length equals capacity, capacity can be omitted")
+				break
+			}
+
+			lenIdent, lenOK := call.Args[1].(*ast.Ident)
+			capIdent, capOK := call.Args[2].(*ast.Ident)
+			if lenOK && capOK && lenIdent.Name == capIdent.Name {
+				f.Errorf(call.Args[1], "when length equals capacity, capacity can be omitted")
+				break
+			}
+
+			lenSel, lenOK := call.Args[1].(*ast.SelectorExpr)
+			capSel, capOK := call.Args[2].(*ast.SelectorExpr)
+			if lenOK && capOK {
+				lenObj := f.Pkg.TypesInfo.ObjectOf(lenSel.Sel)
+				capObj := f.Pkg.TypesInfo.ObjectOf(capSel.Sel)
+				if lenObj != nil && capObj != nil && lenObj.Pos() == capObj.Pos() {
+					f.Errorf(call.Args[1], "when length equals capacity, capacity can be omitted")
+					break
+				}
+			}
+		}
+		return false
+	}
+	f.Walk(fn)
+}
+
+func constantInt(f *lint.File, expr ast.Expr) (int, bool) {
+	tv := f.Pkg.TypesInfo.Types[expr]
+	if tv.Value == nil {
+		return 0, false
+	}
+	if tv.Value.Kind() != constant.Int {
+		return 0, false
+	}
+	v, ok := constant.Int64Val(tv.Value)
+	if !ok {
+		return 0, false
+	}
+	return int(v), true
 }

--- a/lint.go
+++ b/lint.go
@@ -1284,7 +1284,7 @@ func LintMakeLenCap(f *lint.File) {
 		switch len(call.Args) {
 		case 2:
 			// make(T, len)
-			if _, ok := call.Args[0].(*ast.ArrayType); ok {
+			if _, ok := f.Pkg.TypesInfo.TypeOf(call.Args[0]).Underlying().(*types.Slice); ok {
 				break
 			}
 			if length, ok := call.Args[1].(*ast.BasicLit); ok && length.Value == "0" {

--- a/testdata/make-lencap.go
+++ b/testdata/make-lencap.go
@@ -3,9 +3,11 @@ package pkg
 func fn() {
 	const c = 0
 	var x, y int
+	type s []int
 	_ = make([]int, 1)
 	_ = make([]int, c)       // constant of 0 maybe due to debugging, math or platform-specific code
 	_ = make([]int, 0)       // length is mandatory for slices, don't suggest removal
+	_ = make(s, 0)           // length is mandatory for slices, don't suggest removal
 	_ = make(chan int, 0)    // MATCH /when length is zero, length can be omitted/
 	_ = make(map[int]int, 0) // MATCH /when length is zero, length can be omitted/
 	_ = make([]int, 1, 1)    // MATCH /when length equals capacity, capacity can be omitted/

--- a/testdata/make-lencap.go
+++ b/testdata/make-lencap.go
@@ -4,10 +4,12 @@ func fn() {
 	const c = 0
 	var x, y int
 	_ = make([]int, 1)
-	_ = make([]int, c)    // constant of 0 maybe due to debugging, math or platform-specific code
-	_ = make([]int, 0)    // MATCH /when length is zero, length can be omitted/
-	_ = make([]int, 1, 1) // MATCH /when length equals capacity, capacity can be omitted/
-	_ = make([]int, x, x) // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, c)       // constant of 0 maybe due to debugging, math or platform-specific code
+	_ = make([]int, 0)       // length is mandatory for slices, don't suggest removal
+	_ = make(chan int, 0)    // MATCH /when length is zero, length can be omitted/
+	_ = make(map[int]int, 0) // MATCH /when length is zero, length can be omitted/
+	_ = make([]int, 1, 1)    // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, x, x)    // MATCH /when length equals capacity, capacity can be omitted/
 	_ = make([]int, 1, 2)
 	_ = make([]int, x, y)
 }

--- a/testdata/make-lencap.go
+++ b/testdata/make-lencap.go
@@ -1,26 +1,13 @@
 package pkg
 
-type S struct {
-	M1 int
-	M2 int
-	S  *S
-}
-
 func fn() {
 	const c = 0
-	var v int
-	var s = S{1, 2, nil}
-	var s1 = S{1, 2, &s}
+	var x, y int
 	_ = make([]int, 1)
-	_ = make([]int, 0)          // MATCH /when length is zero, length can be omitted/
-	_ = make([]int, c)          // MATCH /when length is zero, length can be omitted/
-	_ = make([]int, 1, 1)       // MATCH /when length equals capacity, capacity can be omitted/
-	_ = make([]int, c, c)       // MATCH /when length equals capacity, capacity can be omitted/
-	_ = make([]int, v, v)       // MATCH /when length equals capacity, capacity can be omitted/
-	_ = make([]int, v, v)       // MATCH /when length equals capacity, capacity can be omitted/
-	_ = make([]int, s.M1, s.M1) // MATCH /when length equals capacity, capacity can be omitted/
-	_ = make([]int, s.M1, s.M2)
-	_ = make([]int, s1.S.M1, s1.S.M1) // MATCH /when length equals capacity, capacity can be omitted/
-	_ = make([]int, s1.S.M1, s1.S.M2)
+	_ = make([]int, c)    // constant of 0 maybe due to debugging, math or platform-specific code
+	_ = make([]int, 0)    // MATCH /when length is zero, length can be omitted/
+	_ = make([]int, 1, 1) // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, x, x) // MATCH /when length equals capacity, capacity can be omitted/
 	_ = make([]int, 1, 2)
+	_ = make([]int, x, y)
 }

--- a/testdata/make-lencap.go
+++ b/testdata/make-lencap.go
@@ -1,0 +1,26 @@
+package pkg
+
+type S struct {
+	M1 int
+	M2 int
+	S  *S
+}
+
+func fn() {
+	const c = 0
+	var v int
+	var s = S{1, 2, nil}
+	var s1 = S{1, 2, &s}
+	_ = make([]int, 1)
+	_ = make([]int, 0)          // MATCH /when length is zero, length can be omitted/
+	_ = make([]int, c)          // MATCH /when length is zero, length can be omitted/
+	_ = make([]int, 1, 1)       // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, c, c)       // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, v, v)       // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, v, v)       // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, s.M1, s.M1) // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, s.M1, s.M2)
+	_ = make([]int, s1.S.M1, s1.S.M1) // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, s1.S.M1, s1.S.M2)
+	_ = make([]int, 1, 2)
+}


### PR DESCRIPTION
See testdata for the main tests, but essentially, for any type T:

- `make(T, 0)` can be simplified to `make(T)` for non slice types
- `make(T, 1, 1)` can be simplified to `make(T, 1)`

Notes:
- I'm ignoring the type, as whether the type is a slice, chan or map, the same rules can be applied
- I'm not convinced on the README wording
- `constantInt` is a function copied from `staticcheck`, if this issue is accepted, perhaps it might be better to move this function to `lintuils`?
- I can remove the redundant selector tests, I was just ensuring it was catching the sel.sel.ident case
- Is there a better way to compare idents or selectors? I feel I maybe doing more work than required.
- I haven't ran this through my smaller corpus, I will be doing over the next 48 hours (slowly updating it now), so I haven't checked for false positives, panics etc